### PR TITLE
 Add functions to accept/reject offers

### DIFF
--- a/db/executer.js
+++ b/db/executer.js
@@ -82,6 +82,8 @@ exports.createAllFunctions = async function createAllFunctions() {
     execute(queries.create.FUNCTION_INSERT_ONE_OFFER);
     execute(queries.create.FUNCTION_UPDATE_OFFER_BY_ASSIGNEE_AND_TASKID);
     execute(queries.create.FUNCTION_UPDATE_TASK_BY_ID);
+    execute(queries.create.FUNCTION_UPDATE_TASK_UPON_ACCEPTING_OFFER_BY_TASK_ID);
+    execute(queries.create.FUNCTION_UPDATE_TASK_UPON_REJECTING_OFFER_BY_TASK_ID);
     execute(queries.create.FUNCTION_CREATE_INDEX_PERSON);
     execute(queries.create.FUNCTION_CREATE_INDEX_TASK);
     execute(queries.create.FUNCTION_CREATE_INDEX_OFFER);
@@ -185,6 +187,16 @@ exports.updateOfferByAssigneeAndTaskId = async function updateOfferByAssigneeAnd
 exports.updateTaskById = async function updateTaskById(task_id, title, description, category_id, location, start_dt, end_dt, price) {
     console.log('Attempting to update task with task_id: %s', task_id);
     return execute(queries.update.TASK_BY_ID, [task_id, title, description, category_id, location, start_dt, end_dt, price]);
+}
+
+exports.updateTaskUponAcceptingOfferByTaskID = async function updateTaskUponAcceptingOfferByTaskID(task_id, assignee, offer_price) {
+    console.log('Attempting to update task status to accepted with task_id: %s', task_id);
+    return execute(queries.update.TASK_UPON_ACCEPTING_OFFER_BY_TASK_ID, [task_id, assignee, offer_price]);
+}
+
+exports.updateTaskUponRejectingOfferByTaskID = async function updateTaskUponRejectingOfferByTaskID(task_id, offer_id) {
+    console.log('Attempting to update offer status to rejected with task_id: %s', task_id);
+    return execute(queries.update.TASK_UPON_REJECTING_OFFER_BY_TASK_ID, [task_id, offer_id]);
 }
 
 //==================================================================================================================================================

--- a/db/queries/create_queries.js
+++ b/db/queries/create_queries.js
@@ -428,6 +428,13 @@ exports.FUNCTION_UPDATE_TASK_UPON_REJECTING_OFFER_BY_TASK_ID = `
     RETURNS void AS
     $BODY$
         BEGIN
+            UPDATE offer
+            SET
+                status_task = 'rejected'
+            WHERE 1=1
+                AND id = _offer_id
+            ;
+
             UPDATE task
             SET
                 status_task = 'open'
@@ -440,13 +447,6 @@ exports.FUNCTION_UPDATE_TASK_UPON_REJECTING_OFFER_BY_TASK_ID = `
                         AND task_id = _task_id
                         AND status_offer IS DISTINCT FROM 'rejected'
                 )
-            ;
-
-            UPDATE offer
-            SET
-                status_task = 'rejected'
-            WHERE 1=1
-                AND id = _offer_id
             ;
         END;
     $BODY$

--- a/db/queries/create_queries.js
+++ b/db/queries/create_queries.js
@@ -6,6 +6,9 @@
     1. Table
     2. View
     3. Functions
+    ├── 3.1. Create
+    ├── 3.2. Insert
+    ├── 3.3. Update
     4. Function calls for Create
 */
 
@@ -68,7 +71,7 @@ exports.TABLE_OFFER_STATUS = `
 exports.TABLE_OFFER = `
     CREATE TABLE IF NOT EXISTS offer (
 	    id		         SERIAL		      	PRIMARY KEY,
-	    task_id		     INTEGER			NOT NULL					REFERENCES task (id) ON DELETE CASCADE,
+	    task_id		     INTEGER			NOT NULL					REFERENCES task (id) ON DELETE NO ACTION,
 	    price			 MONEY			    NOT NULL,
 	    assignee		 VARCHAR(25)		NOT NULL					REFERENCES person (username) ON DELETE CASCADE,
 	    offered_dt	     TIMESTAMP		    NOT NULL,
@@ -157,6 +160,57 @@ exports.VIEW_ALL_OFFER = `
 
 //======================================================================================================================
 // 3. Functions
+
+// ======================================================
+// 3.1. Create
+
+exports.FUNCTION_CREATE_INDEX_PERSON = `
+    CREATE OR REPLACE FUNCTION create_index_table_person ()
+    RETURNS void AS
+    $BODY$
+        BEGIN
+            CREATE INDEX IF NOT EXISTS idx_person_role          ON person (role             DESC);
+            CREATE INDEX IF NOT EXISTS idx_person_created_dt    ON person (created_dt       DESC);
+        END;
+    $BODY$
+    LANGUAGE 'plpgsql' VOLATILE
+    COST 100
+    ;
+`
+
+exports.FUNCTION_CREATE_INDEX_TASK = `
+    CREATE OR REPLACE FUNCTION create_index_table_task ()
+    RETURNS void AS
+    $BODY$
+        BEGIN
+            CREATE INDEX IF NOT EXISTS idx_task_category_id     ON task (category_id);
+            CREATE INDEX IF NOT EXISTS idx_task_requester       ON task (requester          DESC);
+            CREATE INDEX IF NOT EXISTS idx_task_status_task     ON task (status_task        DESC);
+            CREATE INDEX IF NOT EXISTS idx_task_assignee        ON task (assignee           NULLS LAST);
+        END;
+    $BODY$
+    LANGUAGE 'plpgsql' VOLATILE
+    COST 100
+    ;
+`
+
+exports.FUNCTION_CREATE_INDEX_OFFER = `
+    CREATE OR REPLACE FUNCTION create_index_table_offer ()
+    RETURNS void AS
+    $BODY$
+        BEGIN
+            CREATE INDEX IF NOT EXISTS idx_offer_task_id        ON offer (task_id);
+            CREATE INDEX IF NOT EXISTS idx_offer_assignee       ON offer (assignee);
+            CREATE INDEX IF NOT EXISTS idx_offer_status_offer   ON offer (status_offer);
+        END;
+    $BODY$
+    LANGUAGE 'plpgsql' VOLATILE
+    COST 100
+    ;
+`
+
+// ======================================================
+// 3.2. Insert
 
 exports.FUNCTION_INSERT_ONE_TASK = `
     CREATE OR REPLACE FUNCTION insert_one_task (
@@ -270,6 +324,9 @@ exports.FUNCTION_INSERT_ONE_OFFER = `
     ;
 `
 
+// ======================================================
+// 3.3. Update
+
 exports.FUNCTION_UPDATE_OFFER_BY_ASSIGNEE_AND_TASKID = `
     CREATE OR REPLACE FUNCTION update_offer_by_assignee_taskid (
         _assignee       VARCHAR(25),
@@ -328,13 +385,34 @@ exports.FUNCTION_UPDATE_TASK_BY_ID = `
     ;
 `
 
-exports.FUNCTION_CREATE_INDEX_PERSON = `
-    CREATE OR REPLACE FUNCTION create_index_table_person ()
+exports.FUNCTION_UPDATE_TASK_UPON_ACCEPTING_OFFER_BY_TASK_ID = `
+    CREATE OR REPLACE FUNCTION update_task_upon_accepting_offer_by_task_id (
+        _task_id             INTEGER,
+        _assignee            VARCHAR(25),
+        _offer_price         MONEY
+    )
     RETURNS void AS
     $BODY$
         BEGIN
-            CREATE INDEX IF NOT EXISTS idx_person_role          ON person (role             DESC);
-            CREATE INDEX IF NOT EXISTS idx_person_created_dt    ON person (created_dt       DESC);
+            UPDATE task
+            SET
+                price = _offer_price,
+                status_task = 'accepted',
+                assignee = _assignee
+            WHERE 1=1
+                AND id = _task_id
+            ;
+
+            UPDATE offer
+            SET
+                status_task =
+                    CASE
+                        WHEN assignee IS NOT DISTINCT FROM _assignee THEN 'accepted'
+                        ELSE 'rejected'
+                    END
+            WHERE 1=1
+                AND task_id = _task_id
+            ;
         END;
     $BODY$
     LANGUAGE 'plpgsql' VOLATILE
@@ -342,30 +420,34 @@ exports.FUNCTION_CREATE_INDEX_PERSON = `
     ;
 `
 
-exports.FUNCTION_CREATE_INDEX_TASK = `
-    CREATE OR REPLACE FUNCTION create_index_table_task ()
+exports.FUNCTION_UPDATE_TASK_UPON_REJECTING_OFFER_BY_TASK_ID = `
+    CREATE OR REPLACE FUNCTION update_task_upon_rejecting_offer_by_task_id (
+        _task_id             INTEGER,
+        _offer_id            INTEGER
+    )
     RETURNS void AS
     $BODY$
         BEGIN
-            CREATE INDEX IF NOT EXISTS idx_task_category_id     ON task (category_id);
-            CREATE INDEX IF NOT EXISTS idx_task_requester       ON task (requester          DESC);
-            CREATE INDEX IF NOT EXISTS idx_task_status_task     ON task (status_task        DESC);
-            CREATE INDEX IF NOT EXISTS idx_task_assignee        ON task (assignee           NULLS LAST);
-        END;
-    $BODY$
-    LANGUAGE 'plpgsql' VOLATILE
-    COST 100
-    ;
-`
+            UPDATE task
+            SET
+                status_task = 'open'
+            WHERE 1=1
+                AND id = _task_id
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM offer
+                    WHERE 1=1
+                        AND task_id = _task_id
+                        AND status_offer IS DISTINCT FROM 'rejected'
+                )
+            ;
 
-exports.FUNCTION_CREATE_INDEX_OFFER = `
-    CREATE OR REPLACE FUNCTION create_index_table_offer ()
-    RETURNS void AS
-    $BODY$
-        BEGIN
-            CREATE INDEX IF NOT EXISTS idx_offer_task_id        ON offer (task_id);
-            CREATE INDEX IF NOT EXISTS idx_offer_assignee       ON offer (assignee);
-            CREATE INDEX IF NOT EXISTS idx_offer_status_offer   ON offer (status_offer);
+            UPDATE offer
+            SET
+                status_task = 'rejected'
+            WHERE 1=1
+                AND id = _offer_id
+            ;
         END;
     $BODY$
     LANGUAGE 'plpgsql' VOLATILE

--- a/db/queries/update_queries.js
+++ b/db/queries/update_queries.js
@@ -25,3 +25,26 @@ exports.TASK_BY_ID =`
         update_task_by_id($1, $2, $3, $4, $5, $6, $7, $8)
     ;
 `
+
+// This function updates the Task_status to 'accepted' and updates all linked offers' statuses to 'rejected'
+/* Input:
+_task_id             INTEGER,
+_assignee            VARCHAR(25),
+_offer_price         MONEY
+*/
+exports.TASK_UPON_ACCEPTING_OFFER_BY_TASK_ID = `
+    SELECT
+        update_task_upon_accepting_offer_by_task_id($1, $2, $3)
+    ;
+`
+
+// This function updates the Task_status to 'open' if all offers are rejected and updates the offer to 'rejected'
+/* Input:
+_task_id             INTEGER,
+_offer_id            INTEGER
+*/
+exports.TASK_UPON_REJECTING_OFFER_BY_TASK_ID = `
+    SELECT
+        update_task_upon_rejecting_offer_by_task_id($1, $2)
+    ;
+`


### PR DESCRIPTION
* Add queries and functions to accept/reject offers.
    * Accepting offer: 
        * Set `status_task` to `accepted`.
        * Set task's price to `offer_price`.
        * Set `assignee`.
        * Reject all other offers by `task_id`.
    * Rejecting offer:
        * Set `status_offer` to `rejected`.
        * If all offers of the task are rejected, set `status_task` to `open`.
* Add sub-heading comments for Create-Functions queries.
* Change constraint of `task_id` in `offer` from `ON DELETE CASCADE` to `ON DELETE NO ACTION`, so that users who offer still can see their offers after the tasks are deleted.

* @karrui Can you please 
    * add an error handling to display `Task has been deleted or doesnt exist` to page view of task.
    * checkout the commit and build the pages on top of this PR to ensure that the Functions run as expected (or you can create a new PR and I will merge mine into yours later).
