### PR TITLE
Add admin powers + Finish up offers pages in profile

### DIFF
--- a/app.js
+++ b/app.js
@@ -201,6 +201,8 @@ app.get('/profile', isLoggedIn, function(req, res) {
     });
 });
 
+// Task related starts here
+
 app.get('/profile/tasks', isLoggedIn, function(req, res) {
     var promise = executer.getTasksByRequester(req.user.username)
     .then(results => {
@@ -254,6 +256,7 @@ app.get('/profile/tasks/accepted', isLoggedIn, function(req, res) {
     });
 });
 
+// Offers related starts here
 app.get('/profile/offers', isLoggedIn, function(req, res) {
     var promise = executer.getTasksWithOffersByOfferAssignee(req.user.username)
     .then(results => {
@@ -267,9 +270,43 @@ app.get('/profile/offers', isLoggedIn, function(req, res) {
     });
 });
 
-app.get('/profile/tasks/:id', isLoggedIn, function(req, res) {
-    let redirectUrl = '/tasks/' + req.params.id;
-    res.redirect(301, redirectUrl);
+app.get('/profile/offers/pending', isLoggedIn, function(req, res) {
+    var promise = executer.getTasksWithPendingOffersByOfferAssignee(req.user.username)
+    .then(results => {
+        var tasks = results.rows;
+        res.render("user_offers_pending", {
+            tasks: tasks
+        });
+    })
+    .catch(err => {
+        res.status(500).render('500', { title: "Sorry, internal server error", message: err });
+    });
+});
+
+app.get('/profile/offers/accepted', isLoggedIn, function(req, res) {
+    var promise = executer.getTasksWithAcceptedOffersByOfferAssignee(req.user.username)
+    .then(results => {
+        var tasks = results.rows;
+        res.render("user_offers_accepted", {
+            tasks: tasks
+        });
+    })
+    .catch(err => {
+        res.status(500).render('500', { title: "Sorry, internal server error", message: err });
+    });
+});
+
+app.get('/profile/offers/rejected', isLoggedIn, function(req, res) {
+    var promise = executer.getTasksWithRejectedOffersByOfferAssignee(req.user.username)
+    .then(results => {
+        var tasks = results.rows;
+        res.render("user_offers_rejected", {
+            tasks: tasks
+        });
+    })
+    .catch(err => {
+        res.status(500).render('500', { title: "Sorry, internal server error", message: err });
+    });
 });
 
 // =====================================

--- a/app.js
+++ b/app.js
@@ -564,11 +564,12 @@ app.post("/reject/offer/:id", isLoggedIn, function(req, res) {
 // =====================================
 // CATEGORIES APIs =====================
 // =====================================
+var allCategories;
 app.get("/categories", redirection, function(req, res) {
     var promise = executer.getCategories()
     .then(results => {
-        var categories = results.rows;
-        res.render("categories", { categories: categories });
+        allCategories = results.rows;
+        res.render("categories", { categories: allCategories });
     })
     .catch(err => {
         res.status(500).render('500', { title: "Sorry, internal server error", message: err });
@@ -579,7 +580,10 @@ app.get("/categories/:id", redirection, function(req, res) {
     var promise = executer.getTasksByCategoryId(req.params['id'])
     .then(results => {
         var tasks = results.rows;
-        res.render("tasks", { tasks: tasks });
+        if (allCategories != null) {
+            var categoryName = allCategories[req.params['id'] - 1].name;
+        }
+        res.render("tasks", { tasks: tasks, categoryName: categoryName });
     })
     .catch(err => {
         res.status(500).render('500', { title: "Sorry, internal server error", message: err });

--- a/app.js
+++ b/app.js
@@ -438,7 +438,7 @@ app.post("/new/offer/:id", isLoggedIn, function(req, res) {
 
 app.post("/edit/offer/:id", isLoggedIn, function(req, res) {
     var task_id = req.params['id'];
-    var assignee = res.locals.currentUser.username;
+    var assignee = req.body.assignee;
     var newPrice = req.body.price;
     var newOffered_dt = new Date().toISOString();
 
@@ -457,7 +457,14 @@ app.post("/edit/offer/:id", isLoggedIn, function(req, res) {
 
 app.post("/delete/offer/:id", isLoggedIn, function(req, res) {
     var task_id = req.body.task_id;
-    var assignee = res.locals.currentUser.username;
+    var assignee = req.body.assignee;
+
+    // extra check
+    if (assignee != res.locals.currentUser.username && res.locals.currentUser.role != 'admin') {
+        req.flash('message', "Oops, you tried to do something you shouldn't have!")
+        var redirectUrl = "/tasks/" + task_id;
+        res.redirect(redirectUrl); // back to page to display errors
+    }
 
     var promise = executer.deleteOfferByAssigneeAndTaskId(assignee, task_id)
     .then(function() {

--- a/db/executer.js
+++ b/db/executer.js
@@ -389,8 +389,23 @@ exports.getAllTasks = async function getAllTasks() {
 
 
 exports.getTasksWithOffersByOfferAssignee = async function getTasksWithOffersByOfferAssignee(offer_assignee) {
-    console.log('Attempting to get tasks and offers by assignee: %s', offer_assignee);
+    console.log('Attempting to get tasks with offers by assignee: %s', offer_assignee);
     return execute(queries.get.TASK_WITH_OFFER_BY_OFFER_ASSIGNEE, [offer_assignee]);
+}
+
+exports.getTasksWithAcceptedOffersByOfferAssignee = async function getTasksWithAcceptedOffersByOfferAssignee(offer_assignee) {
+    console.log('Attempting to get tasks with accepted offers by assignee: %s', offer_assignee);
+    return execute(queries.get.TASK_WITH_ACCEPTED_OFFER_BY_OFFER_ASSIGNEE, [offer_assignee]);
+}
+
+exports.getTasksWithPendingOffersByOfferAssignee = async function getTasksWithPendingOffersByOfferAssignee(offer_assignee) {
+    console.log('Attempting to get tasks with pending offers by assignee: %s', offer_assignee);
+    return execute(queries.get.TASK_WITH_PENDING_OFFER_BY_OFFER_ASSIGNEE, [offer_assignee]);
+}
+
+exports.getTasksWithRejectedOffersByOfferAssignee = async function getTasksWithRejectedOffersByOfferAssignee(offer_assignee) {
+    console.log('Attempting to get tasks with rejected offers by assignee: %s', offer_assignee);
+    return execute(queries.get.TASK_WITH_REJECTED_OFFER_BY_OFFER_ASSIGNEE, [offer_assignee]);
 }
 
 exports.getTasksByCategoryId = async function getTasksByCategoryId(category_id) {

--- a/db/queries/get_queries.js
+++ b/db/queries/get_queries.js
@@ -100,6 +100,90 @@ exports.TASK_WITH_OFFER_BY_OFFER_ASSIGNEE = `
     ;
 `
 
+exports.TASK_WITH_ACCEPTED_OFFER_BY_OFFER_ASSIGNEE = `
+    SELECT
+        view_all_task.id,
+        view_all_task.title,
+        view_all_task.description,
+        view_all_task.category_id,
+        view_all_task.category_name,
+        view_all_task.location,
+        view_all_task.requester,
+        view_all_task.start_dt,
+        view_all_task.end_dt,
+        view_all_task.price AS task_price,
+        view_all_task.status_task,
+        view_all_task.assignee AS task_assignee,
+        view_all_offer.id AS offer_id,
+        view_all_offer.price AS offer_price,
+        view_all_offer.assignee AS offer_assignee,
+        view_all_offer.offered_dt,
+        view_all_offer.status_offer
+    FROM view_all_task
+    INNER JOIN view_all_offer
+        ON view_all_offer.task_id = view_all_task.id
+    WHERE 1=1
+        AND view_all_offer.assignee = $1
+        AND view_all_offer.status_offer = 'accepted'
+    ;
+`
+
+exports.TASK_WITH_PENDING_OFFER_BY_OFFER_ASSIGNEE = `
+    SELECT
+        view_all_task.id,
+        view_all_task.title,
+        view_all_task.description,
+        view_all_task.category_id,
+        view_all_task.category_name,
+        view_all_task.location,
+        view_all_task.requester,
+        view_all_task.start_dt,
+        view_all_task.end_dt,
+        view_all_task.price AS task_price,
+        view_all_task.status_task,
+        view_all_task.assignee AS task_assignee,
+        view_all_offer.id AS offer_id,
+        view_all_offer.price AS offer_price,
+        view_all_offer.assignee AS offer_assignee,
+        view_all_offer.offered_dt,
+        view_all_offer.status_offer
+    FROM view_all_task
+    INNER JOIN view_all_offer
+        ON view_all_offer.task_id = view_all_task.id
+    WHERE 1=1
+        AND view_all_offer.assignee = $1
+        AND view_all_offer.status_offer = 'pending'
+    ;
+`
+
+exports.TASK_WITH_REJECTED_OFFER_BY_OFFER_ASSIGNEE = `
+    SELECT
+        view_all_task.id,
+        view_all_task.title,
+        view_all_task.description,
+        view_all_task.category_id,
+        view_all_task.category_name,
+        view_all_task.location,
+        view_all_task.requester,
+        view_all_task.start_dt,
+        view_all_task.end_dt,
+        view_all_task.price AS task_price,
+        view_all_task.status_task,
+        view_all_task.assignee AS task_assignee,
+        view_all_offer.id AS offer_id,
+        view_all_offer.price AS offer_price,
+        view_all_offer.assignee AS offer_assignee,
+        view_all_offer.offered_dt,
+        view_all_offer.status_offer
+    FROM view_all_task
+    INNER JOIN view_all_offer
+        ON view_all_offer.task_id = view_all_task.id
+    WHERE 1=1
+        AND view_all_offer.assignee = $1
+        AND view_all_offer.status_offer = 'rejected'
+    ;
+`
+
 exports.TASK_BY_REQUESTER = `
     SELECT
         view_all_task.id,

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -2,6 +2,18 @@ body {
     font-family: "Lato";
 }
 
+.jumbotron {
+    padding: 0 0;
+}
+
+.jumbotron h1 {
+    font-size: 4em;
+}
+
+.jumbotron p {
+    font-size: 1.5em;
+}
+
 #landing {
     background: url(https://i.imgur.com/ThMB6BV.jpg);
     background-size: cover;

--- a/views/edit_task.ejs
+++ b/views/edit_task.ejs
@@ -2,7 +2,7 @@
 <link href="/css/bootstrap-datetimepicker.css" rel="stylesheet" type="text/css">
 
 <div class="container">
-    <% if (currentUser.username != task.requester)  { %>
+    <% if (currentUser.username != task.requester && currentUser.role != 'admin')  { %>
         <div class="container">
             <div class="row">
                 <div class="col-md-12 text-center">
@@ -18,7 +18,7 @@
                 </div>
             </div>
         </div>
-        <% } else { %>
+    <% } else { %>
     <div class="row">
         <h1 style="text-align: center;">Edit task</h1>
         <div style="width:40%; margin: 0 auto">

--- a/views/task_page.ejs
+++ b/views/task_page.ejs
@@ -112,9 +112,34 @@
           </div>
         <% } %>
 
-        <% if (loggedIn && currentUser.username == task.requester) { %>
-          <% if (task.status_task != 'accepted') { %>
-            <a class="btn btn-warning" href="/edit/task/<%= task.id %>">Edit this task!</a>
+        <% if (loggedIn && (currentUser.username == task.requester || currentUser.role == 'admin')) { %>
+          <% if (task.status_task != 'accepted' || currentUser.role == 'admin') { %>
+            <form action="/delete/task/<%=task.id%>" method="POST">
+              <a class="btn btn-warning" href="/edit/task/<%= task.id %>">Edit this task!</a>
+                  <input type="hidden" name="id" value="<%=task.id%>" readonly>
+                  <button class="btn btn-danger pull-right" type="button" data-toggle="modal" data-target="#confirmDelete" data-title="Delete task" data-message="Are you sure you want to delete this task?">
+                      <i class="glyphicon glyphicon-trash"></i>
+                  </button>
+              </form>
+  
+              <!-- Modal Dialog -->
+              <div class="modal fade" id="confirmDelete" role="dialog" aria-labelledby="confirmDeleteLabel" aria-hidden="true">
+                  <div class="modal-dialog">
+                  <div class="modal-content">
+                      <div class="modal-header">
+                      <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+                      <h4 class="modal-title">Delete Permanently</h4>
+                      </div>
+                      <div class="modal-body">
+                      <p>Are you sure about this?</p>
+                      </div>
+                      <div class="modal-footer">
+                      <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                      <button type="button" class="btn btn-danger" id="confirm">Delete</button>
+                      </div>
+                  </div>
+                  </div>
+              </div>
           <% } else { %>
             You have accepted this task! Contact <%=task.assignee%> to finalize details.
         <% } } %>
@@ -134,54 +159,6 @@
                 <a class="btn btn-info" href="/login">Login to offer!</a>
                 <a href="/signup">Or sign up now!</a>
               <% } else if (loggedIn && typeof offerByUser != 'undefined') { %>
-                You have already offered!
-                <div class="row">
-                  <div class="col-md-12">
-                    <div id="offer_info" style="display:none">
-                      <!-- Edit offer -->
-                      <form action="/edit/offer/<%=task.id%>" method="POST">
-                        <div class="form-group">
-                          <div class="input-group">
-                            <span class="input-group-addon">$</span>
-                            <input type="text" name="price" class="form-control" value="<%= offerByUser.price %>">
-                            <span class="input-group-btn">
-                              <button class="btn btn-primary" type="submit">Submit!</button>
-                            </span>
-                          </div>
-                        </div>
-                      </form>
-                    </div>
-                    <a class="btn btn-warning pull-left" id="offer_btn" href="#">Edit offer!</a>
-
-
-                    <!-- Delete offer -->
-                    <form action="/delete/offer/<%=task.id%>" method="POST">
-                      <input type="hidden" name="task_id" value="<%=task.id%>" readonly>
-                      <button class="btn btn-danger pull-left" type="button" data-toggle="modal" data-target="#confirmDelete" data-title="Delete offer"
-                        data-message="Are you sure you want to delete this offer?">
-                        <i class="glyphicon glyphicon-trash"></i>
-                      </button>
-                    </form>
-                  </div>
-                </div>
-                <!-- Modal Dialog -->
-                <div class="modal fade" id="confirmDelete" role="dialog" aria-labelledby="confirmDeleteLabel" aria-hidden="true">
-                  <div class="modal-dialog">
-                    <div class="modal-content">
-                      <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-                        <h4 class="modal-title">Delete Permanently</h4>
-                      </div>
-                      <div class="modal-body">
-                        <p>Are you sure about this?</p>
-                      </div>
-                      <div class="modal-footer">
-                        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                        <button type="button" class="btn btn-danger" id="confirm">Delete</button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
               <% } else if (loggedIn && currentUser.username != task.requester) { %>
                 <form action="/new/offer/<%=task.id%>" method="POST">
                   <div class="form-group">
@@ -209,7 +186,51 @@
                   <%= offer.price %> at
                   <%= new Date(offer.offered_dt + 'Z') %>
                 </div>
-                <% } else if (loggedIn && offer.status_offer != 'rejected') { %>
+                <div class="panel-footer">
+                    <!-- Edit offer -->
+                    <form id="offer_info" style="display:none" action="/edit/offer/<%=task.id%>" method="POST">
+                      <div class="form-group">
+                        <div class="input-group">
+                          <span class="input-group-addon">$</span>
+                          <input type="text" name="price" class="form-control" value="<%= offerByUser.price %>">
+                          <input type="hidden" name="assignee" class="form-control" value="<%= offer.assignee %>" readonly>
+                          <span class="input-group-btn">
+                            <button class="btn btn-primary" type="submit">Submit!</button>
+                          </span>
+                        </div>
+                      </div>
+                    </form>
+                  <a class="btn btn-warning btn-xs" id="offer_btn" href="#">Edit</a>
+                  <!-- Delete offer -->
+                  <form style="display: inline-block;" action="/delete/offer/<%=task.id%>" method="POST">
+                    <input type="hidden" name="task_id" value="<%=task.id%>" readonly>
+                    <input type="hidden" name="assignee" value="<%=offer.assignee%>" readonly>
+                    <button class="btn btn-danger btn-xs" type="button" data-toggle="modal" data-target="#confirmDelete" data-title="Delete offer"
+                      data-message="Are you sure you want to delete this offer?">
+                      <i class="glyphicon glyphicon-trash"></i>
+                    </button>
+                  </form>
+
+                  <!-- Modal Dialog -->
+                <div class="modal fade" id="confirmDelete" role="dialog" aria-labelledby="confirmDeleteLabel" aria-hidden="true">
+                  <div class="modal-dialog">
+                    <div class="modal-content">
+                      <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+                        <h4 class="modal-title">Delete Permanently</h4>
+                      </div>
+                      <div class="modal-body">
+                        <p>Are you sure about this?</p>
+                      </div>
+                      <div class="modal-footer">
+                        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                        <button type="button" class="btn btn-danger" id="confirm">Delete</button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                </div>
+                <% } else if (offer.status_offer != 'rejected') { %>
                   <div class="panel-body">
                     <%= offer.assignee %> offered $
                     <%= offer.price %> at
@@ -233,6 +254,37 @@
                     <input type="hidden" name="offer_id" value="<%=offer.id%>" readonly>
                     <input type="submit" class="btn btn-danger btn-xs" value="Reject offer">
                   </form>
+                </div>
+              <% } else if (loggedIn && currentUser.role == 'admin') { %>
+                <div class="panel-footer">
+                  <!-- Delete offer -->
+                  <form style="display: inline-block;" action="/delete/offer/<%=task.id%>" method="POST">
+                    <input type="hidden" name="task_id" value="<%=task.id%>" readonly>
+                    <input type="hidden" name="assignee" value="<%=offer.assignee%>" readonly>
+                    <button class="btn btn-danger btn-xs" type="button" data-toggle="modal" data-target="#confirmDelete" data-title="Delete offer"
+                      data-message="Are you sure you want to delete this offer?">
+                      Admin Delete <i class="glyphicon glyphicon-trash"></i>
+                    </button>
+                  </form>
+
+                  <!-- Modal Dialog -->
+                <div class="modal fade" id="confirmDelete" role="dialog" aria-labelledby="confirmDeleteLabel" aria-hidden="true">
+                  <div class="modal-dialog">
+                    <div class="modal-content">
+                      <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+                        <h4 class="modal-title">Delete Permanently</h4>
+                      </div>
+                      <div class="modal-body">
+                        <p>Are you sure about this?</p>
+                      </div>
+                      <div class="modal-footer">
+                        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                        <button type="button" class="btn btn-danger" id="confirm">Delete</button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
                 </div>
               <% } %>
             </div>

--- a/views/task_page.ejs
+++ b/views/task_page.ejs
@@ -159,7 +159,7 @@
                 <a class="btn btn-info" href="/login">Login to offer!</a>
                 <a href="/signup">Or sign up now!</a>
               <% } else if (loggedIn && typeof offerByUser != 'undefined') { %>
-              <% } else if (loggedIn && currentUser.username != task.requester) { %>
+              <% } else if (loggedIn && currentUser.username != task.requester && currentUser.role != 'admin') { %>
                 <form action="/new/offer/<%=task.id%>" method="POST">
                   <div class="form-group">
                     <div id="offer_info" style="display:none;" class="input-group">

--- a/views/tasks.ejs
+++ b/views/tasks.ejs
@@ -88,7 +88,7 @@
                         <% } %>
                     </p>
                     <p>Starting offer: $<%= task.price %></p>
-                    <% if (loggedIn && currentUser.username == task.requester) { %>
+                    <% if (loggedIn && (currentUser.username == task.requester || currentUser.role == 'admin')) { %>
                         <form action="/delete/task/<%=task.id%>" method="POST">
                         <a class="btn btn-info" href="/tasks/<%=task.id%>">Task Details</a>
                         <a class="btn btn-warning" href="/edit/task/<%= task.id %>">Edit this task!</a>

--- a/views/tasks.ejs
+++ b/views/tasks.ejs
@@ -9,14 +9,20 @@
         <span class="breadcrumb-item active"> Tasks</span>
     </nav>
     
-     <!-- show any error messages -->
-     <% if (typeof message != 'undefined' && message.length > 0) { %>
+    <!-- show any error messages -->
+    <% if (typeof message != 'undefined' && message.length > 0) { %>
         <div class="alert alert-danger alert-dismissible"><%= message %></div>
     <% } %>
     <!-- show any success messages -->
     <% if (typeof success != 'undefined' && success.length > 0) { %>
         <div class="alert alert-success alert-dismissible"><%= success %></div>
     <% } %>
+
+    <h1>
+        <% if (typeof categoryName != 'undefined') { %>
+            <%=categoryName%>
+        <% } %>
+    </h1>
     
     <header class="jumbotron">
         <div class="container">

--- a/views/user_offers.ejs
+++ b/views/user_offers.ejs
@@ -11,8 +11,8 @@
 
     <div class="page-header text-center">
         <h1><span class="fa fa-anchor"></span> Profile Page</h1>
-        <a href="/profile/tasks" class="btn btn-sm btn-info active">Your tasks</a>
-        <a href="/profile/offers" class="btn btn-primary btn-sm">Your offers</a>
+        <a href="/profile/tasks" class="btn btn-sm btn-info">Your tasks</a>
+        <a href="/profile/offers" class="btn btn-primary active btn-sm">Your offers</a>
         <a href="/tasks" class="btn btn-default btn-sm">All tasks</a>
         <a href="/categories" class="btn btn-default btn-sm">All categories</a>
     </div>
@@ -20,8 +20,9 @@
     <div class="page-header text-center">
             <h1><span class="fa fa-anchor"></span> Current offers</h1>
             <a href="/profile/offers" class="btn btn-primary active btn-sm">All your offers</a>
-            <a href="/profile/offers/accepted" class="btn btn-info btn-sm">Accepted offers</a>
-            <a href="/profile/offers/rejected" class="btn btn-warning btn-sm">Rejected offers</a>
+            <a href="/profile/offers/accepted" class="btn btn-default btn-sm">Accepted offers</a>
+            <a href="/profile/offers/pending" class="btn btn-default btn-sm">Pending offers</a>
+            <a href="/profile/offers/rejected" class="btn btn-default btn-sm">Rejected offers</a>
         </div>
     
     <div class="row">
@@ -49,6 +50,7 @@
                                 </span>
                             <% } %>
                         </p>
+                    <p>Task original price: $<%= task.task_price %></p>
                     <p>You offered: $<%= task.offer_price %></p>
                     <a class="btn btn-info" href="/tasks/<%=task.id%>">Task Details</a>
                     <a href="/tasks/<%=task.id%>">Go to task details to edit/ remove your offer</a>

--- a/views/user_offers.ejs
+++ b/views/user_offers.ejs
@@ -34,7 +34,21 @@
                     <p>Description: <%= task.description %></p>
                     <p>Start: <%= task.start_dt %></p>
                     <p>End: <%= task.end_dt %></p>
-                    <p>Status: <%= task.status_task %></p>
+                    <p>Status: 
+                            <% if (task.status_task === 'accepted') { %>
+                                <span class="label label-success lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } else if (task.status_task === 'offered') { %>
+                                <span class="label label-info lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } else { %>
+                                <span class="label label-warning lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } %>
+                        </p>
                     <p>You offered: $<%= task.offer_price %></p>
                     <a class="btn btn-info" href="/tasks/<%=task.id%>">Task Details</a>
                     <a href="/tasks/<%=task.id%>">Go to task details to edit/ remove your offer</a>

--- a/views/user_offers_accepted.ejs
+++ b/views/user_offers_accepted.ejs
@@ -6,23 +6,23 @@
         You are currently at:
         <a class="breadcrumb-item" href="/">Home</a> >
         <a class="breadcrumb-item" href="/profile">Profile</a> >
-        <span class="breadcrumb-item active"> My tasks</span>
+        <span class="breadcrumb-item active"> My offers</span>
     </nav>
 
     <div class="page-header text-center">
         <h1><span class="fa fa-anchor"></span> Profile Page</h1>
-        <a href="/profile/tasks" class="btn btn-sm btn-primary active">Your tasks</a>
-        <a href="/profile/offers" class="btn btn-info btn-sm">Your offers</a>
+        <a href="/profile/tasks" class="btn btn-sm btn-info">Your tasks</a>
+        <a href="/profile/offers" class="btn btn-primary active btn-sm">Your offers</a>
         <a href="/tasks" class="btn btn-default btn-sm">All tasks</a>
         <a href="/categories" class="btn btn-default btn-sm">All categories</a>
     </div>
 
     <div class="page-header text-center">
-            <h1><span class="fa fa-anchor"></span> Current tasks</h1>
-            <a href="/profile/tasks" class="btn btn-default btn-sm">All your tasks</a>
-            <a href="/profile/tasks/open" class="btn btn-default btn-sm">Open tasks</a>
-            <a href="/profile/tasks/offered" class="btn btn-default btn-sm">Offered tasks</a>
-            <a href="/profile/tasks/accepted" class="btn btn-primary active btn-sm">Accepted tasks</a>
+            <h1><span class="fa fa-anchor"></span> Current offers</h1>
+            <a href="/profile/offers" class="btn btn-default btn-sm">All your offers</a>
+            <a href="/profile/offers/accepted" class="btn btn-primary active btn-sm">Accepted offers</a>
+            <a href="/profile/offers/pending" class="btn btn-default btn-sm">Pending offers</a>
+            <a href="/profile/offers/rejected" class="btn btn-default btn-sm">Rejected offers</a>
         </div>
     
     <div class="row">
@@ -50,13 +50,15 @@
                                 </span>
                             <% } %>
                         </p>
-                    <p>Starting offer: <%= task.price %></p>
+                    <p>Task original price: $<%= task.task_price %></p>
+                    <p>You offered: $<%= task.offer_price %></p>
                     <a class="btn btn-info" href="/tasks/<%=task.id%>">Task Details</a>
-                    <a class="btn btn-warning" href="/edit/task/<%= task.id %>">Edit this task!</a>
+                    <a href="/tasks/<%=task.id%>">Go to task details to edit/ remove your offer</a>
                 </div>
+                <div class="panel-footer">Requested by: <%= task.requester %></div>
             </div>
+            
             <% }); %>
         </div>
-        
         
         <% include partials/footer %>

--- a/views/user_offers_accepted.ejs
+++ b/views/user_offers_accepted.ejs
@@ -35,7 +35,21 @@
                     <p>Description: <%= task.description %></p>
                     <p>Start: <%= task.start_dt %></p>
                     <p>End: <%= task.end_dt %></p>
-                    <p>Status: <%= task.status_task %></p>
+                    <p>Status: 
+                            <% if (task.status_task === 'accepted') { %>
+                                <span class="label label-success lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } else if (task.status_task === 'offered') { %>
+                                <span class="label label-info lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } else { %>
+                                <span class="label label-warning lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } %>
+                        </p>
                     <p>Starting offer: <%= task.price %></p>
                     <a class="btn btn-info" href="/tasks/<%=task.id%>">Task Details</a>
                     <a class="btn btn-warning" href="/edit/task/<%= task.id %>">Edit this task!</a>

--- a/views/user_offers_offered.ejs
+++ b/views/user_offers_offered.ejs
@@ -35,7 +35,21 @@
                     <p>Description: <%= task.description %></p>
                     <p>Start: <%= task.start_dt %></p>
                     <p>End: <%= task.end_dt %></p>
-                    <p>Status: <%= task.status_task %></p>
+                    <p>Status: 
+                            <% if (task.status_task === 'accepted') { %>
+                                <span class="label label-success lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } else if (task.status_task === 'offered') { %>
+                                <span class="label label-info lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } else { %>
+                                <span class="label label-warning lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } %>
+                        </p>
                     <p>Starting offer: <%= task.price %></p>
                     <a class="btn btn-info" href="/tasks/<%=task.id%>">Task Details</a>
                     <a class="btn btn-warning" href="/edit/task/<%= task.id %>">Edit this task!</a>

--- a/views/user_offers_open.ejs
+++ b/views/user_offers_open.ejs
@@ -35,7 +35,21 @@
                     <p>Description: <%= task.description %></p>
                     <p>Start: <%= task.start_dt %></p>
                     <p>End: <%= task.end_dt %></p>
-                    <p>Status: <%= task.status_task %></p>
+                    <p>Status: 
+                            <% if (task.status_task === 'accepted') { %>
+                                <span class="label label-success lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } else if (task.status_task === 'offered') { %>
+                                <span class="label label-info lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } else { %>
+                                <span class="label label-warning lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } %>
+                        </p>
                     <p>Starting offer: <%= task.price %></p>
                     <a class="btn btn-info" href="/tasks/<%=task.id%>">Task Details</a>
                     <a class="btn btn-warning" href="/edit/task/<%= task.id %>">Edit this task!</a>

--- a/views/user_offers_pending.ejs
+++ b/views/user_offers_pending.ejs
@@ -6,23 +6,23 @@
         You are currently at:
         <a class="breadcrumb-item" href="/">Home</a> >
         <a class="breadcrumb-item" href="/profile">Profile</a> >
-        <span class="breadcrumb-item active"> My tasks</span>
+        <span class="breadcrumb-item active"> My offers</span>
     </nav>
 
     <div class="page-header text-center">
         <h1><span class="fa fa-anchor"></span> Profile Page</h1>
-        <a href="/profile/tasks" class="btn btn-sm btn-primary active">Your tasks</a>
-        <a href="/profile/offers" class="btn btn-info btn-sm">Your offers</a>
+        <a href="/profile/tasks" class="btn btn-sm btn-info">Your tasks</a>
+        <a href="/profile/offers" class="btn btn-primary active btn-sm">Your offers</a>
         <a href="/tasks" class="btn btn-default btn-sm">All tasks</a>
         <a href="/categories" class="btn btn-default btn-sm">All categories</a>
     </div>
 
     <div class="page-header text-center">
-            <h1><span class="fa fa-anchor"></span> Current tasks</h1>
-            <a href="/profile/tasks" class="btn btn-default btn-sm">All your tasks</a>
-            <a href="/profile/tasks/open" class="btn btn-primary active btn-sm">Open tasks</a>
-            <a href="/profile/tasks/offered" class="btn btn-default btn-sm">Offered tasks</a>
-            <a href="/profile/tasks/accepted" class="btn btn-default btn-sm">Accepted tasks</a>
+            <h1><span class="fa fa-anchor"></span> Current offers</h1>
+            <a href="/profile/offers" class="btn btn-default btn-sm">All your offers</a>
+            <a href="/profile/offers/accepted" class="btn btn-default btn-sm">Accepted offers</a>
+            <a href="/profile/offers/pending" class="btn btn-primary active btn-sm">Pending offers</a>
+            <a href="/profile/offers/rejected" class="btn btn-default btn-sm">Rejected offers</a>
         </div>
     
     <div class="row">
@@ -50,13 +50,15 @@
                                 </span>
                             <% } %>
                         </p>
-                    <p>Starting offer: <%= task.price %></p>
+                    <p>Task original price: $<%= task.task_price %></p>
+                    <p>You offered: $<%= task.offer_price %></p>
                     <a class="btn btn-info" href="/tasks/<%=task.id%>">Task Details</a>
-                    <a class="btn btn-warning" href="/edit/task/<%= task.id %>">Edit this task!</a>
+                    <a href="/tasks/<%=task.id%>">Go to task details to edit/ remove your offer</a>
                 </div>
+                <div class="panel-footer">Requested by: <%= task.requester %></div>
             </div>
+            
             <% }); %>
         </div>
-        
         
         <% include partials/footer %>

--- a/views/user_offers_rejected.ejs
+++ b/views/user_offers_rejected.ejs
@@ -6,23 +6,23 @@
         You are currently at:
         <a class="breadcrumb-item" href="/">Home</a> >
         <a class="breadcrumb-item" href="/profile">Profile</a> >
-        <span class="breadcrumb-item active"> My tasks</span>
+        <span class="breadcrumb-item active"> My offers</span>
     </nav>
 
     <div class="page-header text-center">
         <h1><span class="fa fa-anchor"></span> Profile Page</h1>
-        <a href="/profile/tasks" class="btn btn-sm btn-info active">Your tasks</a>
+        <a href="/profile/tasks" class="btn btn-sm btn-info">Your tasks</a>
         <a href="/profile/offers" class="btn btn-primary active btn-sm">Your offers</a>
         <a href="/tasks" class="btn btn-default btn-sm">All tasks</a>
         <a href="/categories" class="btn btn-default btn-sm">All categories</a>
     </div>
 
     <div class="page-header text-center">
-            <h1><span class="fa fa-anchor"></span> Current tasks</h1>
-            <a href="/profile/tasks" class="btn btn-primary active btn-sm">All your tasks</a>
-            <a href="/profile/tasks/open" class="btn btn-default btn-sm">Open tasks</a>
-            <a href="/profile/tasks/offered" class="btn btn-default btn-sm">Offered tasks</a>
-            <a href="/profile/tasks/accepted" class="btn btn-default btn-sm">Accepted tasks</a>
+            <h1><span class="fa fa-anchor"></span> Current offers</h1>
+            <a href="/profile/offers" class="btn btn-default btn-sm">All your offers</a>
+            <a href="/profile/offers/accepted" class="btn btn-default btn-sm">Accepted offers</a>
+            <a href="/profile/offers/pending" class="btn btn-default btn-sm">Pending offers</a>
+            <a href="/profile/offers/rejected" class="btn btn-primary active btn-sm">Rejected offers</a>
         </div>
     
     <div class="row">
@@ -50,13 +50,15 @@
                                 </span>
                             <% } %>
                         </p>
-                    <p>Starting offer: <%= task.price %></p>
+                    <p>Task original price: $<%= task.task_price %></p>
+                    <p>You offered: $<%= task.offer_price %></p>
                     <a class="btn btn-info" href="/tasks/<%=task.id%>">Task Details</a>
-                    <a class="btn btn-warning" href="/edit/task/<%= task.id %>">Edit this task!</a>
+                    <a href="/tasks/<%=task.id%>">Go to task details to edit/ remove your offer</a>
                 </div>
+                <div class="panel-footer">Requested by: <%= task.requester %></div>
             </div>
+            
             <% }); %>
         </div>
-        
         
         <% include partials/footer %>

--- a/views/user_tasks.ejs
+++ b/views/user_tasks.ejs
@@ -35,10 +35,25 @@
                     <p>Description: <%= task.description %></p>
                     <p>Start: <%= task.start_dt %></p>
                     <p>End: <%= task.end_dt %></p>
-                    <p>Status: <%= task.status_task %></p>
+                    <p>Status: 
+                            <% if (task.status_task === 'accepted') { %>
+                                <span class="label label-success lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } else if (task.status_task === 'offered') { %>
+                                <span class="label label-info lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } else { %>
+                                <span class="label label-warning lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } %>
+                        </p>
                     <p>Starting offer: <%= task.price %></p>
                     <form action="/delete/task/<%=task.id%>" method="POST">
                         <a class="btn btn-info" href="/tasks/<%=task.id%>">Task Details</a>
+                        <% if (task.status_task != 'accepted') { %>
                         <a class="btn btn-warning" href="/edit/task/<%= task.id %>">Edit this task!</a>
                         
                             <input type="hidden" name="id" value="<%=task.id%>" readonly>
@@ -65,6 +80,7 @@
                             </div>
                             </div>
                         </div>
+                        <% } %>
                 </div>
             </div>
             <% }); %>

--- a/views/user_tasks_accepted.ejs
+++ b/views/user_tasks_accepted.ejs
@@ -35,37 +35,23 @@
                     <p>Description: <%= task.description %></p>
                     <p>Start: <%= task.start_dt %></p>
                     <p>End: <%= task.end_dt %></p>
-                    <p>Status: <%= task.status_task %></p>
+                    <p>Status: 
+                            <% if (task.status_task === 'accepted') { %>
+                                <span class="label label-success lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } else if (task.status_task === 'offered') { %>
+                                <span class="label label-info lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } else { %>
+                                <span class="label label-warning lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } %>
+                        </p>
                     <p>Starting offer: <%= task.price %></p>
-                    <form action="/delete/task/<%=task.id%>" method="POST">
-                        <a class="btn btn-info" href="/tasks/<%=task.id%>">Task Details</a>
-                        <a class="btn btn-warning" href="/edit/task/<%= task.id %>">Edit this task!</a>
-                        
-                            <input type="hidden" name="id" value="<%=task.id%>" readonly>
-                            <button class="btn btn-danger pull-right" type="button" data-toggle="modal" data-target="#confirmDelete" data-title="Delete task" data-message="Are you sure you want to delete this task?">
-                                <i class="glyphicon glyphicon-trash"></i>
-                            </button>
-                        </form>
-            
-                        <!-- Modal Dialog -->
-                        <div class="modal fade" id="confirmDelete" role="dialog" aria-labelledby="confirmDeleteLabel" aria-hidden="true">
-                            <div class="modal-dialog">
-                            <div class="modal-content">
-                                <div class="modal-header">
-                                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-                                <h4 class="modal-title">Delete Permanently</h4>
-                                </div>
-                                <div class="modal-body">
-                                <p>Are you sure about this?</p>
-                                </div>
-                                <div class="modal-footer">
-                                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-                                <button type="button" class="btn btn-danger" id="confirm">Delete</button>
-                                </div>
-                            </div>
-                            </div>
-                        </div>
-                </div>
+                    <a class="btn btn-info" href="/tasks/<%=task.id%>">Task Details</a>
             </div>
             <% }); %>
         </div>

--- a/views/user_tasks_offered.ejs
+++ b/views/user_tasks_offered.ejs
@@ -35,7 +35,21 @@
                     <p>Description: <%= task.description %></p>
                     <p>Start: <%= task.start_dt %></p>
                     <p>End: <%= task.end_dt %></p>
-                    <p>Status: <%= task.status_task %></p>
+                    <p>Status: 
+                            <% if (task.status_task === 'accepted') { %>
+                                <span class="label label-success lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } else if (task.status_task === 'offered') { %>
+                                <span class="label label-info lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } else { %>
+                                <span class="label label-warning lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } %>
+                        </p>
                     <p>Starting offer: <%= task.price %></p>
                     <form action="/delete/task/<%=task.id%>" method="POST">
                         <a class="btn btn-info" href="/tasks/<%=task.id%>">Task Details</a>

--- a/views/user_tasks_open.ejs
+++ b/views/user_tasks_open.ejs
@@ -35,7 +35,21 @@
                     <p>Description: <%= task.description %></p>
                     <p>Start: <%= task.start_dt %></p>
                     <p>End: <%= task.end_dt %></p>
-                    <p>Status: <%= task.status_task %></p>
+                    <p>Status: 
+                            <% if (task.status_task === 'accepted') { %>
+                                <span class="label label-success lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } else if (task.status_task === 'offered') { %>
+                                <span class="label label-info lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } else { %>
+                                <span class="label label-warning lb-md">
+                                    <%= task.status_task %>
+                                </span>
+                            <% } %>
+                        </p>
                     <p>Starting offer: <%= task.price %></p>
                     <form action="/delete/task/<%=task.id%>" method="POST">
                         <a class="btn btn-info" href="/tasks/<%=task.id%>">Task Details</a>


### PR DESCRIPTION
Clean up UI for editing for offers / rejecting offers

**Admin powers added**
- Delete tasks
- Delete offers (cannot edit offers, that will be weirdddddddd)
- Edit tasks

**Fix bad pages for Profile > Offers**
- The pages now redirect to the correct tasks with offers depending on the status instead of 404ing.

**Add executer queries related to offer retrieval**
- `executer.getTasksWithAcceptedOffersByOfferAssignee(assignee)`
- `executer.getTasksWithPendingOffersByOfferAssignee(assignee)`
- `executer.getTasksWithRejectedOffersByOfferAssignee(assignee)`

Self explainatory